### PR TITLE
upgrade to 0.26.2

### DIFF
--- a/Formula/infection.rb
+++ b/Formula/infection.rb
@@ -1,15 +1,15 @@
 class Infection < Formula
   desc "AST based PHP Mutation Testing Framework"
   homepage "https://infection.github.io"
-  url "https://github.com/infection/infection/releases/download/0.14.1/infection.phar"
-  version "0.14.1"
-  sha256 "0c7f9325d7f6406de2a1fb36c6c7ceba2aa5ffbd74d1f390eb2290f28a857f29"
+  url "https://github.com/infection/infection/releases/download/0.26.2/infection.phar"
+  version "0.26.2"
+  sha256 "dc1063c29880b52978d87621c8e03b83d53ff57338807c335705152ac4ba464e"
 
-  depends_on "php72-xdebug" if Formula["php72"].linked_keg.exist?
+  depends_on "php" => :test
 
   resource "pubkey" do
-    url "https://github.com/infection/infection/releases/download/0.14.1/infection.phar.asc"
-    sha256 "32a3bb69b5df83f3b9668125cf10b901df766018b1ef2b91826c835fa1bf414c"
+    url "https://github.com/infection/infection/releases/download/0.26.2/infection.phar.asc"
+    sha256 "bacf2698ef48789fee23bd9570eb5466904bbd1e8cf43376e7f97c1f0a27f06d"
   end
 
   def install


### PR DESCRIPTION
Hereby a bump to the latest version of infection.

I've also modified the depends_on part since the entire install mechanisme of xdebug on php has changed quite a bit in homebrew

(it's based on the [phpunit formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/phpunit.rb))